### PR TITLE
Chore/context support pg header

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package droplet
 
 import (
 	"context"
+	"net/http"
 )
 
 type Context interface {
@@ -16,7 +17,10 @@ type Context interface {
 	Output() interface{}
 	SetPath(path string)
 	Path() string
+	ResponseHeader() http.Header
 }
+
+var _ Context = &emptyContext{}
 
 type emptyContext struct {
 	cxt    context.Context
@@ -24,12 +28,14 @@ type emptyContext struct {
 	input  interface{}
 	output interface{}
 	path   string
+	rh     http.Header
 }
 
 func NewContext() *emptyContext {
 	c := &emptyContext{}
 	c.dict = make(map[string]interface{})
 	c.cxt = context.TODO()
+	c.rh = http.Header{}
 	return c
 }
 
@@ -88,4 +94,8 @@ func (c *emptyContext) SetPath(path string) {
 
 func (c *emptyContext) Path() string {
 	return c.path
+}
+
+func (c *emptyContext) ResponseHeader() http.Header {
+	return c.rh
 }

--- a/data/resp.go
+++ b/data/resp.go
@@ -37,6 +37,7 @@ type FileResponse struct {
 	ContentType   string
 	Content       []byte
 	ContentReader io.ReadCloser
+	StatusCode    int
 }
 
 func (r *FileResponse) Get() *FileResponse {

--- a/middleware/http_resp_reshap.go
+++ b/middleware/http_resp_reshap.go
@@ -32,7 +32,7 @@ func (mw *HttpRespReshapeMiddleware) Handle(ctx droplet.Context) error {
 		resp.Set(code, message, d)
 		resp.SetReqID(ctx.GetString(KeyRequestID))
 		ctx.SetOutput(resp)
-		// response reshape is the last step, so we don't need return error
+		// response reshape is the last step, so we don't need to return error
 		return nil
 	}
 

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -44,6 +44,10 @@ func HandleHttpInPipeline(input HandleHttpInPipelineInput) {
 		SetOrchestrator(opt.Orchestrator).
 		Run(input.Handler, droplet.InitContext(dCtx))
 
+	for k, _ := range dCtx.ResponseHeader() {
+		input.RespWriter.SetHeader(k, dCtx.ResponseHeader().Get(k))
+	}
+
 	switch ret.(type) {
 	case droplet.RawHttpResponse:
 		rr := ret.(droplet.RawHttpResponse)

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -60,6 +60,9 @@ func HandleHttpInPipeline(input HandleHttpInPipelineInput) {
 		if fileResp.ContentType == "" {
 			fileResp.ContentType = "application/octet-stream"
 		}
+		if fileResp.StatusCode > 0 {
+			input.RespWriter.WriteHeader(fileResp.StatusCode)
+		}
 		input.RespWriter.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileResp.Name))
 		input.RespWriter.SetHeader("Content-type", fileResp.ContentType)
 		if fileResp.ContentReader != nil {


### PR DESCRIPTION
Related To #13 , now can use `ctx.ResponseHeader().Set(key, value)` to set response header by programing